### PR TITLE
[Fix] 레포지토리 설정 뷰 UI 겹치는 문제 해결

### DIFF
--- a/Gitodo/Sources/IssueInfo/IssueInfoView.swift
+++ b/Gitodo/Sources/IssueInfo/IssueInfoView.swift
@@ -14,11 +14,6 @@ import SnapKit
 
 class IssueInfoView: UIView {
     
-    private let insetFromSuperView: CGFloat = 20.0
-    private let insetFromBodyContainerView: CGFloat = 10.0
-    private let offsetFromOtherView: CGFloat = 20.0
-    private let offsetFromFriendView: CGFloat = 10.0
-    
     // MARK: - UI Components
     
     private lazy var scrollView = UIScrollView()
@@ -91,36 +86,36 @@ class IssueInfoView: UIView {
         
         contentView.addSubview(titleLabel)
         titleLabel.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.leading.trailing.equalToSuperview().inset(20)
         }
         
         contentView.addSubview(labelsLabel)
         labelsLabel.snp.makeConstraints { make in
-            make.top.equalTo(titleLabel.snp.bottom).offset(offsetFromOtherView)
-            make.leading.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(titleLabel.snp.bottom).offset(20)
+            make.leading.equalToSuperview().inset(20)
         }
         
         contentView.addSubview(labelsView)
         labelsView.snp.makeConstraints { make in
-            make.top.equalTo(labelsLabel.snp.bottom).offset(offsetFromFriendView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(labelsLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
         }
         
         contentView.addSubview(assigneesLabel)
         assigneesLabel.snp.makeConstraints { make in
-            make.top.equalTo(labelsView.snp.bottom).offset(offsetFromOtherView)
-            make.leading.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(labelsView.snp.bottom).offset(20)
+            make.leading.equalToSuperview().inset(20)
         }
         
         contentView.addSubview(assigneesView)
         assigneesView.snp.makeConstraints { make in
-            make.top.equalTo(assigneesLabel.snp.bottom).offset(offsetFromFriendView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(assigneesLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
         }
         
         contentView.addSubview(separatorView)
         separatorView.snp.makeConstraints { make in
-            make.top.equalTo(assigneesView.snp.bottom).offset(offsetFromOtherView)
+            make.top.equalTo(assigneesView.snp.bottom).offset(20)
             make.horizontalEdges.equalToSuperview()
             make.height.equalTo(3)
         }
@@ -129,19 +124,19 @@ class IssueInfoView: UIView {
         bodyContainerView.snp.makeConstraints { make in
             make.top.equalTo(separatorView.snp.bottom)
             make.leading.trailing.equalToSuperview()
-            make.bottom.lessThanOrEqualToSuperview().inset(insetFromSuperView * 2)
+            make.bottom.lessThanOrEqualToSuperview().inset(20 * 2)
             make.height.greaterThanOrEqualTo(400)
         }
         
         bodyContainerView.addSubview(markdownView)
         markdownView.snp.makeConstraints { make in
-            make.horizontalEdges.bottom.equalToSuperview().inset(insetFromBodyContainerView)
+            make.horizontalEdges.bottom.equalToSuperview().inset(10)
             make.top.equalToSuperview()
         }
         
         bodyContainerView.addSubview(loadingTextView)
         loadingTextView.snp.makeConstraints { make in
-            make.edges.equalToSuperview().inset(insetFromSuperView * 2)
+            make.edges.equalToSuperview().inset(20 * 2)
         }
     }
     

--- a/Gitodo/Sources/RepositoryInfo/RepositoryInfoView.swift
+++ b/Gitodo/Sources/RepositoryInfo/RepositoryInfoView.swift
@@ -16,10 +16,6 @@ class RepositoryInfoView: UIView {
     private var viewModel: RepositoryInfoViewModel?
     private let disposeBag = DisposeBag()
     
-    private let insetFromSuperView: CGFloat = 20.0
-    private let offsetFromOtherView: CGFloat = 15.0
-    private let offsetFromFriendView: CGFloat = 10.0
-    
     // MARK: - UI Components
     
     private lazy var previewLabel: UILabel = {
@@ -89,12 +85,12 @@ class RepositoryInfoView: UIView {
     private func setupLayout() {
         addSubview(previewLabel)
         previewLabel.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.leading.trailing.equalToSuperview().inset(20)
         }
         
         addSubview(previewView)
         previewView.snp.makeConstraints { make in
-            make.top.equalTo(previewLabel.snp.bottom).offset(offsetFromFriendView)
+            make.top.equalTo(previewLabel.snp.bottom).offset(10)
             make.centerX.equalToSuperview()
             make.width.equalTo(60)
             make.height.equalTo(80)
@@ -102,46 +98,46 @@ class RepositoryInfoView: UIView {
         
         addSubview(separator)
         separator.snp.makeConstraints { make in
-            make.top.equalTo(previewView.snp.bottom).offset(offsetFromOtherView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(previewView.snp.bottom).offset(15)
+            make.leading.trailing.equalToSuperview().inset(20)
             make.height.equalTo(1)
         }
         
         addSubview(nicknamelabel)
         nicknamelabel.snp.makeConstraints { make in
-            make.top.equalTo(separator.snp.bottom).offset(offsetFromOtherView)
-            make.leading.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(separator.snp.bottom).offset(15)
+            make.leading.equalToSuperview().inset(20)
         }
         
         addSubview(nicknameTextField)
         nicknameTextField.snp.makeConstraints { make in
-            make.top.equalTo(nicknamelabel.snp.bottom).offset(offsetFromFriendView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(nicknamelabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
         }
         
         addSubview(symbolLabel)
         symbolLabel.snp.makeConstraints { make in
-            make.top.equalTo(nicknameTextField.snp.bottom).offset(offsetFromOtherView)
-            make.leading.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(nicknameTextField.snp.bottom).offset(15)
+            make.leading.equalToSuperview().inset(20)
         }
         
         addSubview(symbolTextField)
         symbolTextField.snp.makeConstraints { make in
-            make.top.equalTo(symbolLabel.snp.bottom).offset(offsetFromFriendView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(symbolLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
         }
         
         addSubview(colorLabel)
         colorLabel.snp.makeConstraints { make in
-            make.top.equalTo(symbolTextField.snp.bottom).offset(offsetFromOtherView)
-            make.leading.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(symbolTextField.snp.bottom).offset(15)
+            make.leading.equalToSuperview().inset(20)
         }
         
         addSubview(colorView)
         colorView.snp.makeConstraints { make in
-            make.top.equalTo(colorLabel.snp.bottom).offset(offsetFromFriendView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
-            make.bottom.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(colorLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.bottom.equalToSuperview().inset(20)
         }
     }
     

--- a/Gitodo/Sources/RepositorySettings/RepositoryCell.swift
+++ b/Gitodo/Sources/RepositorySettings/RepositoryCell.swift
@@ -13,13 +13,13 @@ class RepositoryCell: UITableViewCell {
     
     static let reuseIdentifier = "RepositoryCell"
     private var repo: MyRepo?
-    private let insetFromSuperView: CGFloat = 20.0
     
     // MARK: - UI Components
     
     private lazy var nameLabel = {
         let label = UILabel()
         label.font = .systemFont(ofSize: 15.0, weight: .medium)
+        label.lineBreakMode = .byTruncatingTail
         return label
     }()
     
@@ -57,13 +57,14 @@ class RepositoryCell: UITableViewCell {
     private func setupLayout() {
         contentView.addSubview(nameLabel)
         nameLabel.snp.makeConstraints { make in
-            make.leading.equalToSuperview().inset(insetFromSuperView)
+            make.leading.equalToSuperview().inset(20)
+            make.trailing.equalToSuperview().inset(45)
             make.centerY.equalToSuperview()
         }
         
         contentView.addSubview(selectedButton)
         selectedButton.snp.makeConstraints { make in
-            make.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.trailing.equalToSuperview().inset(20)
             make.centerY.equalToSuperview()
             make.width.height.equalTo(15)
         }
@@ -77,6 +78,7 @@ class RepositoryCell: UITableViewCell {
     
     func selectCell() -> MyRepo? {
         selectedButton.isHidden.toggle()
+        
         return repo
     }
     

--- a/Gitodo/Sources/RepositorySettings/RepositorySettingsView.swift
+++ b/Gitodo/Sources/RepositorySettings/RepositorySettingsView.swift
@@ -22,11 +22,6 @@ class RepositorySettingsView: UIView {
     private let disposeBag = DisposeBag()
     weak var delegate: RepositorySettingsDelegate?
     
-    private let insetFromSuperView: CGFloat = 20.0
-    private let insetFromContentSuperViewTop: CGFloat = 10.0
-    private let offsetFromPreviewView: CGFloat = 10.0
-    private let offsetFromOtherView: CGFloat = 25.0
-    private let offsetFromFriendView: CGFloat = 10.0
     private let heightForRow: CGFloat = 50.0
     private var repoTableViewHeightConstraint: Constraint?
     private var deletedRepoTableViewHeightConstraint: Constraint?
@@ -81,13 +76,13 @@ class RepositorySettingsView: UIView {
     private func setupLayout() {
         addSubview(previewView)
         previewView.snp.makeConstraints { make in
-            make.top.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.leading.trailing.equalToSuperview().inset(20)
             make.height.equalTo(80)
         }
         
         addSubview(scrollView)
         scrollView.snp.makeConstraints { make in
-            make.top.equalTo(previewView.snp.bottom).offset(offsetFromPreviewView)
+            make.top.equalTo(previewView.snp.bottom).offset(10)
             make.leading.trailing.bottom.equalToSuperview()
         }
         
@@ -99,29 +94,29 @@ class RepositorySettingsView: UIView {
         
         contentView.addSubview(repoLabel)
         repoLabel.snp.makeConstraints { make in
-            make.top.equalToSuperview().inset(insetFromContentSuperViewTop)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalToSuperview().inset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
         }
         
         contentView.addSubview(repoTableView)
         repoTableView.snp.makeConstraints { make in
-            make.top.equalTo(repoLabel.snp.bottom).offset(offsetFromFriendView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(repoLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
             self.repoTableViewHeightConstraint = make.height.equalTo(0).constraint
         }
         
         contentView.addSubview(deletedRepoLabel)
         deletedRepoLabel.snp.makeConstraints { make in
-            make.top.equalTo(repoTableView.snp.bottom).offset(offsetFromOtherView)
-            make.leading.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(repoTableView.snp.bottom).offset(25)
+            make.leading.equalToSuperview().inset(20)
         }
         
         contentView.addSubview(deletedRepoTableView)
         deletedRepoTableView.snp.makeConstraints { make in
-            make.top.equalTo(deletedRepoLabel.snp.bottom).offset(offsetFromFriendView)
-            make.leading.trailing.equalToSuperview().inset(insetFromSuperView)
+            make.top.equalTo(deletedRepoLabel.snp.bottom).offset(10)
+            make.leading.trailing.equalToSuperview().inset(20)
             self.deletedRepoTableViewHeightConstraint = make.height.equalTo(0).constraint
-            make.bottom.equalToSuperview().inset(insetFromSuperView)
+            make.bottom.equalToSuperview().inset(20)
         }
     }
     


### PR DESCRIPTION
<!--

✅ PR 전 체크 리스트 !!!
- PR 제목: [Feature/Fix/Refactor] 작업 요약
- Target Branch 확인: 적절한 branch로 요청했는지 확인해주세요.
- Assignees 지정: 담당자를 지정해주세요.
- Labels 추가: 적절한 라벨을 붙여주세요.

-->

## 📌 개요
<!-- PR내용에 대해 축약해서 적어주세요. -->
레포지토리 설정 뷰 UI 겹치는 문제 해결


## 👩🏻‍💻 작업 내용
<!-- 변경된 사항에 대해 상세하게 기술해주세요. -->
- 레포지토리 이름 Label에 대해 trailing 제약을 설정하여 UI가 겹치는 문제를 해결했습니다.
- insetFromXXXView, offsetFromXXXView 등의 변수를 삭제했습니다.


## 📸 스크린샷
(UI가 겹칠만큼 긴 레포지토리 이름이 없어서 스크린샷 찍을 때만 임시로 테이블 뷰의 width를 줄임 😅)
|![IMG_8046](https://github.com/goorung/Gitodo/assets/116897060/728eabfc-1321-497f-a650-ccaa8575f803)|![IMG_8047](https://github.com/goorung/Gitodo/assets/116897060/65fb5bbb-c7c8-4de5-80f5-b9ff7960b2c9)|
|-|-|


## 🔗 관련 이슈
<!-- 관련 이슈 번호를 링크로 연결해주세요. 예: closes #4242 -->
closes #53 