### PR TITLE
[Refactor/Fix] 테이블뷰가 그려지기 전에 로딩 뷰가 사라지는 문제 해결

### DIFF
--- a/Gitodo/Sources/Base/LoadableView.swift
+++ b/Gitodo/Sources/Base/LoadableView.swift
@@ -59,7 +59,7 @@ class LoadableView: UIView {
     }
     
     func hideLoading() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { [weak self] in
+        DispatchQueue.main.async { [weak self] in
             self?.loadingIndicator.stopAnimating()
             self?.loadingView.isHidden = true
         }

--- a/Gitodo/Sources/Base/LoadableView.swift
+++ b/Gitodo/Sources/Base/LoadableView.swift
@@ -59,10 +59,8 @@ class LoadableView: UIView {
     }
     
     func hideLoading() {
-        DispatchQueue.main.async { [weak self] in
-            self?.loadingIndicator.stopAnimating()
-            self?.loadingView.isHidden = true
-        }
+        loadingIndicator.stopAnimating()
+        loadingView.isHidden = true
     }
     
 }

--- a/Gitodo/Sources/Issue/IssueViewModel.swift
+++ b/Gitodo/Sources/Issue/IssueViewModel.swift
@@ -38,7 +38,7 @@ final class IssueViewModel: BaseViewModel {
     
     private let issues = BehaviorRelay<[Issue]>(value: [])
     private let issueState = BehaviorRelay<IssueState>(value: .hasIssues)
-    private let isLoading = BehaviorRelay<Bool>(value: false)
+    private let isLoading = BehaviorRelay<Bool>(value: true)
     
     private var currentRepo: MyRepo?
     
@@ -80,7 +80,6 @@ final class IssueViewModel: BaseViewModel {
     }
     
     private func handleActiveRepo(repo: MyRepo) {
-        isLoading.accept(true)
         Task {
             do {
                 let allIssues = try await APIManager.shared.fetchIssues(for: repo)

--- a/Gitodo/Sources/Organization/OrganizationViewModel.swift
+++ b/Gitodo/Sources/Organization/OrganizationViewModel.swift
@@ -33,7 +33,7 @@ final class OrganizationViewModel: BaseViewModel {
     private let viewDidLoad = PublishSubject<Void>()
     
     private let organizations = BehaviorRelay<[Organization]>(value: [])
-    private let isLoading = BehaviorRelay<Bool>(value: false)
+    private let isLoading = BehaviorRelay<Bool>(value: true)
     
     private var me: String?
     
@@ -59,7 +59,6 @@ final class OrganizationViewModel: BaseViewModel {
     }
     
     private func fetchOrganizations() {
-        isLoading.accept(true)
         Task {
             do {
                 let me = try await APIManager.shared.fetchMe()

--- a/Gitodo/Sources/Repository/RepositoryViewModel.swift
+++ b/Gitodo/Sources/Repository/RepositoryViewModel.swift
@@ -35,7 +35,7 @@ final class RepositoryViewModel: BaseViewModel {
     private let togglePublic = PublishSubject<IndexPath>()
     
     private let repositoryCellViewModels = BehaviorRelay<[RepositoryCellViewModel]>(value: [])
-    private let isLoading = BehaviorRelay<Bool>(value: false)
+    private let isLoading = BehaviorRelay<Bool>(value: true)
     
     private let owner: Organization
     private var repositories: [Repository]?
@@ -77,7 +77,6 @@ final class RepositoryViewModel: BaseViewModel {
     }
     
     private func fetchRepositoriesWithLocal() {
-        isLoading.accept(true)
         Task {
             do {
                 // fetch


### PR DESCRIPTION
<!--

✅ PR 전 체크 리스트 !!!
- PR 제목: [Feature/Fix/Refactor] 작업 요약
- Target Branch 확인: 적절한 branch로 요청했는지 확인해주세요.
- Assignees 지정: 담당자를 지정해주세요.
- Labels 추가: 적절한 라벨을 붙여주세요.

-->

## 📌 개요
<!-- PR내용에 대해 축약해서 적어주세요. -->
API를 통해 받아오는 데이터를 테이블뷰에 그리기 전에 로딩 뷰가 사라지는 문제를 해결합니다.


## 👩🏻‍💻 작업 내용
<!-- 변경된 사항에 대해 상세하게 기술해주세요. -->
뷰모델의 로딩 상태 초기값을 `false`에서 `true`로 변경하고 로딩 뷰를 숨기는 메서드에서 비동기 코드를 제거했습니다.

[ 기존 로딩 상태 흐름 ] false -> true -> false

문제점: 로딩 뷰가 너무 빨리 사라지는 것을 방지하기 위해 로딩 뷰를 숨기는 메서드에서 0.3초 지연을 추가했으나, 이로 인해 실제 로딩 상태가 다음과 같이 변화함
  1) 0.3초 < API 응답 시간 : true(API 요청 전) -> false(초기값) -> false(API 응답 후) 또는
  2) 0.3초 > API 응답 시간 : true(API 요청 전) -> false(API 응답 후) -> false(초기값)

-> 결과적으로 로딩 뷰가 최대 0.3초만 표시되는 문제 발생

[ 개선된 로딩 상태 흐름 ] true(초기값) -> false(API 응답 후)

|변경 전|변경 후|
|-|-|
|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-26 at 01 53 13](https://github.com/user-attachments/assets/41f80fcc-727a-45f3-a5d6-b7daceb9da9e)|![Simulator Screen Recording - iPhone 15 Pro - 2024-07-26 at 04 14 01](https://github.com/user-attachments/assets/868cdd81-cc2f-40b8-973b-a84d8253875b)|




## 🔗 관련 이슈
<!-- 관련 이슈 번호를 링크로 연결해주세요. 예: closes #4242 -->
